### PR TITLE
Add circom-lsp for neovim support

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -20,6 +20,22 @@
             solc.overlay
           ];
         };
+        circom-lsp = pkgs.rustPlatform.buildRustPackage rec {
+          pname = "circom-lsp";
+          version = "0.1.3";  # Specify the correct version
+
+          src = pkgs.fetchFromGitHub {
+            owner = "rubydusa";  # Specify the owner
+            repo = pname;
+            rev = "v${version}";
+            sha256 = "sha256-Y71qmeDUh6MwSlFrSnG+Nr/un5szTUo27+J/HphGr7M=";  # Provide the correct hash
+          };
+
+          cargoSha256 = "sha256-Lq8SpzkUqYgayQTApNngOlhceAQAPG9Rwg1pmGvyxnM=";  # Provide the correct cargo hash
+          sourceRoot = "source/server";
+          doCheck = false;
+        };
+
       in 
       with pkgs;
       {
@@ -29,6 +45,7 @@
             circom
             solc_0_8_24
             (solc.mkDefault pkgs solc_0_8_24)
+            circom-lsp
           ];
         };
       }    


### PR DESCRIPTION
This builds circom lsp so it is possible to run the lsp in neovim. 

This is specific to neovim. 

You can add this to your plugins to make it all work: 

```
return {
  "iden3/vim-circom-syntax",
}
```